### PR TITLE
Fix crash on unknown package

### DIFF
--- a/pispy/widgets/package_info.py
+++ b/pispy/widgets/package_info.py
@@ -288,7 +288,7 @@ class PackageInfo(VerticalScroll):
             )
         else:
             # Report that we didn't find it.
-            await self.query_one(PackageInfo).mount(Label("Not found", classes="error"))
+            await self.mount(Label("Not found", classes="error"))
 
 
 ### package_info.py ends here


### PR DESCRIPTION
By the looks of things, this comes from the day when a query of a widget, for itself, would find itself. That was quickly removed from Textual but it seems that by accident or design this code worked with that.

Fixes #3.