### PR TITLE
feat: prevent package info focus if none

### DIFF
--- a/pispy/app.py
+++ b/pispy/app.py
@@ -42,10 +42,6 @@ class PISpy(App[None]):
         yield Input(placeholder="Name of the package to look up in PyPI")
         yield PackageInfo()
 
-    def on_mount(self) -> None:
-        """Configure the screen once loaded up."""
-        self.query_one(Input).focus()
-
     @on(Input.Submitted)
     async def lookup_package(self) -> None:
         """React to the user hitting enter in the input field."""

--- a/pispy/widgets/package_info.py
+++ b/pispy/widgets/package_info.py
@@ -200,6 +200,10 @@ class PackageInfo(VerticalScroll):
     }
     """
 
+    def on_mount(self) -> None:
+        # Initally prevent focus until there is package info to navigate
+        self.can_focus = False
+
     async def show(self, package_name: str) -> None:
         """Show the package information for the given package.
 
@@ -266,8 +270,10 @@ class PackageInfo(VerticalScroll):
                     ),
                 )
             )
+            self.can_focus = True
         else:
             # Report that we didn't find it.
+            self.can_focus = False
             await self.mount(Label("Not found", classes="error"))
 
 


### PR DESCRIPTION
I know this project is a work in progress, so if you don't want PRs obviously feel free to close this!

This prevents focussing `PackageInfo` is there is none, whether before any search or if not found.

