### PR TITLE
Add simple CLI support for a package name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # PISpy ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Add support for passing a package name on the command line.
+
 ## 0.5.0
 
 **Released: 2024-04-12**

--- a/pispy/app.py
+++ b/pispy/app.py
@@ -1,6 +1,10 @@
 """Provides the main application class."""
 
 ##############################################################################
+# Python imports.
+import sys
+
+##############################################################################
 # Textual imports.
 from textual import on
 from textual.app import App, ComposeResult
@@ -42,9 +46,16 @@ class PISpy(App[None]):
         yield Input(placeholder="Name of the package to look up in PyPI")
         yield PackageInfo()
 
-    def on_mount(self) -> None:
-        """Configure the screen once loaded up."""
-        self.query_one(Input).focus()
+    async def on_mount(self) -> None:
+        """Pre-fill the display if a package is passed on the command line."""
+        try:
+            # TODO: doing it via argv is icky, but it's handy for a quick
+            # hack. Once I've revamped the UI I'll switch to argparse, and
+            # probably add an inline switch.
+            self.query_one(Input).value = sys.argv[1]
+        except IndexError:
+            return
+        await self.lookup_package()
 
     @on(Input.Submitted)
     async def lookup_package(self) -> None:
@@ -60,6 +71,7 @@ class PISpy(App[None]):
         self.query_one(Input).value = package
         self.query_one(Input).cursor_position = len(package)
         await self.lookup_package()
+
 
 ##############################################################################
 def run() -> None:


### PR DESCRIPTION
Once I've revamped the UI I'll switch to argparse, and probably add an inline switch, but for now this is quick and handy.