### PR TITLE
Don't show download count, it's always -1 for PyPI

### DIFF
--- a/pispy/widgets/package_information.py
+++ b/pispy/widgets/package_information.py
@@ -208,7 +208,6 @@ class PackageURLDetails(TabPane):
                 ("MD5 Digest", self._url.md5_digest, Value),
                 ("Uploaded", self._url.upload_time_iso_8601, Value),
                 ("Has Signature", "Yes" if self._url.has_sig else "No", Value),
-                ("Downloads", f"{self._url.downloads:,}", Value),
                 ("Comments", self._url.comment_text, Value),
                 *((name, value, Value) for name, value in self._url.digests.items()),
                 ("Yanked", "Yes" if self._url.yanked else "No", Value),


### PR DESCRIPTION
The downloads count is always -1 in the JSON response for PyPI packages, so we might as well not show it:

https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html

That says 0, but it was later changed to -1 to make it more obviously not-real.

(It's possible other package indexes do return a download count, but it looks like this tool only checks PyPI, and I would expect that to be the most common one anyway.)