### PR TITLE
De-duplicate and sort required packages

### DIFF
--- a/pispy/widgets/package_information.py
+++ b/pispy/widgets/package_information.py
@@ -304,8 +304,14 @@ class PackageDetails(TabPane):
                 (
                     "Requires",
                     ", ".join(
-                        f"[@click=screen.lookup('{pkg.project_name}')]{pkg.project_name}[/]"
-                        for pkg in parse_requirements(self._package.requires_dist)
+                        sorted(
+                            set(
+                                f"[@click=screen.lookup('{pkg.project_name}')]{pkg.project_name}[/]"
+                                for pkg in parse_requirements(
+                                    self._package.requires_dist
+                                )
+                            )
+                        )
                     ),
                     Value,
                 ),


### PR DESCRIPTION
Pillow has a number of optional dependencies ("extras"), and some of them duplicate a package (defusedxml, olefile):

https://github.com/python-pillow/Pillow/blob/f8160b858aebf8b7bffdefba48735feac300a060/pyproject.toml#L41-L73

This means we get duplicates when running `pispy pillow`:

<img width="830" alt="image" src="https://github.com/davep/pispy/assets/1324225/254fa38d-dc79-4478-9cd0-1ebd239b1c3e">

This PR de-duplicates them by putting them in a set first, and we might as well sort them too:

<img width="743" alt="image" src="https://github.com/davep/pispy/assets/1324225/d3db9637-4d9e-46d5-886d-35f3fd7553ca">
