### PR TITLE
Allow following links from a Markdown package description

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 **Released: WiP**
 
 - Updated Textual and fixed breakage.
+- Added link-following support to the package description pane, when the
+  description is seen as Markdown and the link can be reasonably followed.
 
 ## 0.7.0
 

--- a/pispy/widgets/package_information.py
+++ b/pispy/widgets/package_information.py
@@ -230,6 +230,16 @@ class PackageDescription(TabPane):
                 else Value
             )(self._package.description, id="description")
 
+    @on(Markdown.LinkClicked)
+    def maybe_handle_url(self, event: Markdown.LinkClicked) -> None:
+        """Maybe handle a link coming from the `Markdown` widget.
+
+        Args:
+            event: The link click event.
+        """
+        if URL.looks_urlish(event.href):
+            visit_url(event.href)
+
 
 ##############################################################################
 class PackageUnknown(TabPane):


### PR DESCRIPTION
Makes some effort to follow links, that can be reasonably followed, when the description of a package is Markdown.